### PR TITLE
Force Markdown to render # in headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ## Scala
  - [Akka](https://github.com/akka/akka) ★5,769
 
-## C#
+## C#  
  - [Nancy](https://github.com/NancyFx/Nancy) ★4,214
 
 ## Go


### PR DESCRIPTION
The Markdown renderer that Github uses is a bit broken when it comes to displaying # as the last letter in a header. Appending spaces forces the renderer to render the # as a literal #.
